### PR TITLE
enclose the directory in case there are spaces

### DIFF
--- a/autocad/tools/chocolateyinstall.ps1
+++ b/autocad/tools/chocolateyinstall.ps1
@@ -148,7 +148,7 @@ $packageArgsUnzip  = @{
   fileType       = 'exe'
   file           = $part1
   softwareName   = 'AutoCAD Installation Files*'
-  silentArgs     = "-suppresslaunch -d '$env:TEMP'"
+  silentArgs     = "-suppresslaunch -d `"$env:TEMP`""
   validExitCodes = @(0, 3010, 1641)
 }
 Install-ChocolateyPackage @packageArgsUnzip

--- a/autocad/tools/chocolateyinstall.ps1
+++ b/autocad/tools/chocolateyinstall.ps1
@@ -148,7 +148,7 @@ $packageArgsUnzip  = @{
   fileType       = 'exe'
   file           = $part1
   softwareName   = 'AutoCAD Installation Files*'
-  silentArgs     = "-suppresslaunch -d $env:TEMP"
+  silentArgs     = "-suppresslaunch -d '$env:TEMP'"
   validExitCodes = @(0, 3010, 1641)
 }
 Install-ChocolateyPackage @packageArgsUnzip


### PR DESCRIPTION
If the directory path has spaces, the installation fails because the SFX extracts to a different place than expected, enclosing the $env:TEMP variable in single quotes should prevent this