### PR TITLE
Added ALLUSERS=1 to silentArgs to ensure shortcuts are created for al…

### DIFF
--- a/designreview/tools/chocolateyinstall.ps1
+++ b/designreview/tools/chocolateyinstall.ps1
@@ -22,7 +22,7 @@ $packageArgs2 = @{
   softwareName  = 'designreview*'
   checksum      = $checksum_file
   checksumType  = 'sha256'
-  silentArgs    = "/q"
+  silentArgs    = "ALLUSERS=1 /q"
   validExitCodes= @(0, 3010, 1641)
 }
 Install-ChocolateyInstallPackage @packageArgs2


### PR DESCRIPTION
DesignReview unfortunately does not create shortcuts when the installation is performed in the scope of the device (e.g. when deploying with Intune).
Adding the argument ALLUSERS=1 corrects this and the installation routine creates start menu and desktop shortcuts for all users.